### PR TITLE
include sys/sysmacros.h for major/minor/makedev

### DIFF
--- a/filesys.c
+++ b/filesys.c
@@ -16,6 +16,7 @@
  */
 
 #include "defs.h"
+#include <sys/sysmacros.h>
 #include <linux/major.h>
 #include <regex.h>
 #include <sys/utsname.h>


### PR DESCRIPTION
These funcs are defined in the sys/sysmacros.h header, not sys/types.h.
Linux C libraries are updating to drop the implicit include, so we need
to include it explicitly.