### PR TITLE
Allow to not include build date, hostname, user

### DIFF
--- a/configure.c
+++ b/configure.c
@@ -1285,7 +1285,9 @@ make_build_data(char *target)
 	lower_case(target_data.program, progname);
 
 	fprintf(fp4, "char *build_command = \"%s\";\n", progname);
-        if (strlen(hostname))
+        if (getenv("SOURCE_DATE_EPOCH"))
+                fprintf(fp4, "char *build_data = \"reproducible build\";\n");
+        else if (strlen(hostname))
                 fprintf(fp4, "char *build_data = \"%s by %s on %s\";\n",
                         strip_linefeeds(inbuf1), inbuf2, hostname);
         else


### PR DESCRIPTION
if indicated by the environment
to allow for reproducible builds

This is slightly stretching the definition of the variable defined at
https://reproducible-builds.org/specs/source-date-epoch/

Signed-off-by: Bernhard M. Wiedemann <bwiedemann@suse.de>


The alternative would be to only include build time information on request
or drop it completely