### PR TITLE
Remove superfluous breaks

### DIFF
--- a/diskdump.c
+++ b/diskdump.c
@@ -1506,11 +1506,9 @@ get_diskdump_regs(struct bt_info *bt, ulong *eip, ulong *esp)
 
 	case EM_MIPS:
 		return get_diskdump_regs_32(bt, eip, esp);
-		break;
 
 	case EM_386:
 		return get_netdump_regs_x86(bt, eip, esp);
-		break;
 
 	case EM_IA_64:
 	       /* For normal backtraces, this information will be obtained
@@ -1523,19 +1521,15 @@ get_diskdump_regs(struct bt_info *bt, ulong *eip, ulong *esp)
 
 	case EM_PPC:
 		return get_diskdump_regs_ppc(bt, eip, esp);
-		break;
 
 	case EM_PPC64:
 		return get_diskdump_regs_ppc64(bt, eip, esp);
-		break;
 
 	case EM_X86_64:
 		return get_netdump_regs_x86_64(bt, eip, esp);
-		break;
 
 	case EM_S390:
 		return machdep->get_stack_frame(bt, eip, esp);
-		break;
 
 	case EM_AARCH64:
 		get_diskdump_regs_arm64(bt, eip, esp);

--- a/netdump.c
+++ b/netdump.c
@@ -2596,7 +2596,6 @@ get_netdump_regs(struct bt_info *bt, ulong *eip, ulong *esp)
 	{
 	case EM_386:
 		return get_netdump_regs_x86(bt, eip, esp);
-		break;
 
 	case EM_IA_64:
 	       /* For normal backtraces, this information will be obtained
@@ -2609,15 +2608,12 @@ get_netdump_regs(struct bt_info *bt, ulong *eip, ulong *esp)
 
 	case EM_PPC:
 		return get_netdump_regs_ppc(bt, eip, esp);
-		break;
 
 	case EM_PPC64:
 		return get_netdump_regs_ppc64(bt, eip, esp);
-		break;
 
 	case EM_X86_64:
 		return get_netdump_regs_x86_64(bt, eip, esp);
-		break;
 
 	case EM_S390:
 		machdep->get_stack_frame(bt, eip, esp);
@@ -2625,15 +2621,12 @@ get_netdump_regs(struct bt_info *bt, ulong *eip, ulong *esp)
 
 	case EM_ARM:
 		return get_netdump_regs_arm(bt, eip, esp);
-		break;
 
 	case EM_AARCH64:
 		return get_netdump_regs_arm64(bt, eip, esp);
-		break;
 
 	case EM_MIPS:
 		return get_netdump_regs_mips(bt, eip, esp);
-		break;
 
 	default:
 		error(FATAL, 

--- a/xen_hyper.c
+++ b/xen_hyper.c
@@ -1109,7 +1109,6 @@ xen_hyper_get_domain_next(int mod, ulong *next)
 				get_symbol_data("dom0", sizeof(void *), next);
 		}
 		return xhdt->domain_struct;
-		break;
 	case XEN_HYPER_DOMAIN_READ_INIT:
 		/* Case of search from context_array. */
 		if (xhdt->context_array && xhdt->context_array->domain) {
@@ -1121,7 +1120,6 @@ xen_hyper_get_domain_next(int mod, ulong *next)
 			return NULL;
 		}
 		return xhdt->domain_struct;
-		break;
 	case XEN_HYPER_DOMAIN_READ_NEXT:
 		break;
 	default :


### PR DESCRIPTION
Remove superfluous breaks, as there is a "return" before them.

Signed-off-by: Liao Pingfang <liao.pingfang@zte.com.cn>