### PR TITLE
Fixed the segment fault when ikconfig passed nonstandard values

### DIFF
--- a/kernel.c
+++ b/kernel.c
@@ -10244,6 +10244,9 @@ static void add_ikconfig_entry(char *line, struct ikconfig_list *ent)
 	sscanf(name, "CONFIG_%s", name);
 	val = strtok_r(NULL, "", &tokptr);
 
+	if (!val)
+		return;
+
 	ent->name = strdup(name);
 	ent->val = strdup(val);
 }


### PR DESCRIPTION
Some strange reasons may cause kcore to collect some strange
entries of ikconfig, such as CONFIG_SECU+[some hex data] causes
the 'val' to be NULL, and then crashes when strdup.

Signed-off-by: Jackie Liu <liuyun01@kylinos.cn>