### PR TITLE
Add support lockless printk ringbuffer

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -2106,6 +2106,18 @@ struct offset_table {                    /* stash of commonly-used offsets */
 	long irq_common_data_affinity;
 	long irq_desc_irq_common_data;
 	long uts_namespace_name;
+	long printk_ringbuffer_count_bits;
+	long printk_ringbuffer_descs;
+	long printk_ringbuffer_infos;
+	long printk_ringbuffer_head_id;
+	long printk_ringbuffer_tail_id;
+	long printk_ringbuffer_size_bits;
+	long printk_ringbuffer_data;
+	long prb_desc_state_var;
+	long prb_desc_text_blk_lpos_begin;
+	long printk_info_ts_nsec;
+	long printk_info_text_len;
+	long printk_info_caller_id;
 };
 
 struct size_table {         /* stash of commonly-used sizes */
@@ -2265,6 +2277,9 @@ struct size_table {         /* stash of commonly-used sizes */
 	long xa_node;
 	long zram_table_entry;
 	long irq_common_data;
+	long printk_ringbuffer;
+	long printk_info;
+	long prb_desc;
 };
 
 struct array_table {


### PR DESCRIPTION
Kernel 5.10 introduce new lockless printk ringbuffer.
This patch dump the new log record, with:
1. treat caller_id as dict info
2. no dev_info support, because no user yet
3. only 5.10 finalized format, not intermit impl in git-tree

This patch unified vmcore & symbol version:
1. vmcore version pre-read prb ptr value
2. pass desired readmem addrtype

Signed-off-by: samuelliao <samuelliao@tencent.com>