### PR TITLE
docs: fix simple typo, psuedo -> pseudo

### DIFF
--- a/xendump.c
+++ b/xendump.c
@@ -429,7 +429,7 @@ xc_save_verify(char *buf)
 	}	
 
 	/* 
-	 *  Get the list of PFNs that are not in the psuedo-phys map 
+	 *  Get the list of PFNs that are not in the pseudo-phys map 
 	 */
 	if (read(xd->xfd, &xd->xc_save.pfns_not, 
 	    sizeof(xd->xc_save.pfns_not)) != sizeof(xd->xc_save.pfns_not))


### PR DESCRIPTION
There is a small typo in xendump.c.

Should read `pseudo` rather than `psuedo`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md