### PR TITLE
scope: add ability to un-set scope

### DIFF
--- a/gdb_interface.c
+++ b/gdb_interface.c
@@ -1012,23 +1012,25 @@ gdb_set_crash_scope(ulong vaddr, char *arg)
 	char name[BUFSIZE];
 	struct load_module *lm;
 
-	if (!is_kernel_text(vaddr)) {
-		error(INFO, "invalid text address: %s\n", arg);
-		return FALSE;
-	}
-
-	if (module_symbol(vaddr, NULL, &lm, name, 0)) {
-		if (!(lm->mod_flags & MOD_LOAD_SYMS)) {
-			error(INFO, "attempting to find/load \"%s\" module debuginfo\n", 
-				lm->mod_name);
-			if (!load_module_symbols_helper(lm->mod_name)) {
-				error(INFO, "cannot find/load \"%s\" module debuginfo\n", 
-					lm->mod_name);
-				return FALSE;
-			}
+	if (vaddr) {
+		if (!is_kernel_text(vaddr)) {
+			error(INFO, "invalid text address: %s\n", arg);
+			return FALSE;
 		}
-	} else if (kt->flags2 & KASLR)
-		vaddr -= (kt->relocate * -1);
+
+		if (module_symbol(vaddr, NULL, &lm, name, 0)) {
+			if (!(lm->mod_flags & MOD_LOAD_SYMS)) {
+				error(INFO, "attempting to find/load \"%s\" module debuginfo\n", 
+					lm->mod_name);
+				if (!load_module_symbols_helper(lm->mod_name)) {
+					error(INFO, "cannot find/load \"%s\" module debuginfo\n", 
+						lm->mod_name);
+					return FALSE;
+				}
+			}
+		} else if (kt->flags2 & KASLR)
+			vaddr -= (kt->relocate * -1);
+	}
 
 	req->command = GNU_SET_CRASH_BLOCK;
 	req->addr = vaddr;

--- a/help.c
+++ b/help.c
@@ -1088,7 +1088,7 @@ char *help_set[] = {
 "                               of data structures; the \"text-addr\" argument",
 "                               must be a kernel or module text address, which", 
 "                               may be expressed symbolically or as a hexadecimal",
-"                               value.",
+"                               value; set scope 0 to un-set.",
 "         offline  show | hide  show or hide command output that is associated",
 "                               with offline cpus.",
 "         redzone  on | off     if on, CONFIG_SLUB object addresses displayed by",


### PR DESCRIPTION
Currently there is no way to un-set the scope without having to
exit and re-enter crash.  The ability to un-set can come in very
useful when running automated pykdump scripts and needing scope to
be cleared between script runs.  Add the ability by allowing
'set scope 0' as a viable command.

Signed-off-by: John Pittman <jpittman@redhat.com>