### PR TITLE
Add lowercase tcr_el1_t1sz

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,7 @@ PROGRAM=crash
 # Supported targets: X86 ALPHA PPC IA64 PPC64 SPARC64
 # TARGET and GDB_CONF_FLAGS will be configured automatically by configure
 #
-TARGET=
+TARGET=X86_64
 GDB_CONF_FLAGS=
 
 ARCH := $(shell uname -m | sed -e s/i.86/i386/ -e s/sun4u/sparc64/ -e s/arm.*/arm/ -e s/sa110/arm/)
@@ -34,10 +34,10 @@ endif
 #
 # GDB, GDB_FILES, GDB_OFILES and GDB_PATCH_FILES will be configured automatically by configure 
 #
-GDB=
-GDB_FILES=
-GDB_OFILES=
-GDB_PATCH_FILES=
+GDB=gdb-7.6
+GDB_FILES=${GDB_7.6_FILES}
+GDB_OFILES=${GDB_7.6_OFILES}
+GDB_PATCH_FILES=gdb-7.6.patch gdb-7.6-ppc64le-support.patch gdb-7.6-proc_service.h.patch
 
 #
 # Default installation directory
@@ -185,7 +185,7 @@ GDB_7.6_OFILES=${GDB}/gdb/symtab.o
 # 
 # GDB_FLAGS is passed up from the gdb Makefile.
 #
-GDB_FLAGS=
+GDB_FLAGS=-DGDB_7_6
 
 #
 # WARNING_OPTIONS and WARNING_ERROR are both applied on a per-file basis. 
@@ -202,7 +202,7 @@ TARGET_CFLAGS=
 
 CRASH_CFLAGS=-g -D${TARGET} ${TARGET_CFLAGS} ${GDB_FLAGS} ${CFLAGS}
 
-GPL_FILES=
+GPL_FILES=COPYING3
 TAR_FILES=${SOURCE_FILES} Makefile ${GPL_FILES} README .rh_rpm_package crash.8 \
 	${EXTENSION_SOURCE_FILES} ${MEMORY_DRIVER_FILES}
 CSCOPE_FILES=${SOURCE_FILES}
@@ -230,7 +230,7 @@ all: make_configure
 gdb_merge: force
 	@if [ ! -f ${GDB}/README ]; then \
 	  make --no-print-directory gdb_unzip; fi
-	@echo "${LDFLAGS} -lz -ldl -rdynamic" > ${GDB}/gdb/mergelibs
+	@echo "${LDFLAGS} -lz -llzo2 -lsnappy -ldl -rdynamic" > ${GDB}/gdb/mergelibs
 	@echo "../../${PROGRAM} ../../${PROGRAM}lib.a" > ${GDB}/gdb/mergeobj
 	@rm -f ${PROGRAM}
 	@if [ ! -f ${GDB}/config.status ]; then \

--- a/arm64.c
+++ b/arm64.c
@@ -3924,7 +3924,8 @@ arm64_calc_VA_BITS(void)
 		} else if (ACTIVE())
 			error(FATAL, "cannot determine VA_BITS_ACTUAL: please use /proc/kcore\n");
 		else {
-			if ((string = pc->read_vmcoreinfo("NUMBER(TCR_EL1_T1SZ)"))) {
+			if ((string = pc->read_vmcoreinfo("NUMBER(TCR_EL1_T1SZ)")) ||
+			    (string = pc->read_vmcoreinfo("NUMBER(tcr_el1_t1sz)"))) {
 				/* See ARMv8 ARM for the description of
 				 * TCR_EL1.T1SZ and how it can be used
 				 * to calculate the vabits_actual

--- a/diskdump.c
+++ b/diskdump.c
@@ -23,6 +23,8 @@
  * GNU General Public License for more details.
  */
 
+#define LZO
+#define SNAPPY
 #include "defs.h"
 #include "diskdump.h"
 #include "xen_dom0.h"

--- a/netdump.c
+++ b/netdump.c
@@ -1927,6 +1927,12 @@ vmcoreinfo_read_string(const char *key)
 			pc->read_vmcoreinfo = no_vmcoreinfo;
 			return value;
 		}
+		if (STREQ(key, "NUMBER(tcr_el1_t1sz)") && nd->arch_data2) {
+			value = calloc(VADDR_PRLEN+1, sizeof(char));
+			sprintf(value, "%lld", ((ulonglong)nd->arch_data2 >> 32) & 0xffffffff);
+			pc->read_vmcoreinfo = no_vmcoreinfo;
+			return value;
+		}
 		if (STREQ(key, "relocate") && nd->arch_data1) {
 			value = calloc(VADDR_PRLEN+1, sizeof(char));
 			sprintf(value, "%lx", nd->arch_data1);


### PR DESCRIPTION
Author: John Donnelly <john.p.donnelly@oracle.com>
Date:   Wed May 12 14:48:03 2021 -0700

    Add lowercase tcr_el1_t1sz
    
    Commit 1c45cea "arm64: Change tcr_el1_t1sz variable name to
    TCR_EL1_T1SZ", renamed a variable to upper case, but there are
    kernels in existence that still have the lower case name, which
    breaks crash backwards compatibility.
    
    Fixes: 1c45cea ("arm64: Change tcr_el1_t1sz variable name to
    TCR_EL1_T1SZ")
    
    Signed-off-by: John Donnelly <john.p.donnelly@oracle.com>