### PR TITLE
Enable use of alternate eppic branch

### DIFF
--- a/extensions/eppic.mk
+++ b/extensions/eppic.mk
@@ -35,7 +35,7 @@ all:
           if [ -f "$(GIT)" ]; \
           then \
              if [ -n "$(EPPIC_GIT_URL)" ]; then \
-               git clone "$(EPPIC_GIT_URL)" eppic; \
+               git clone $(EPPIC_GIT_URL) eppic; \
              else \
 	          if ping -c 1 -W 5 github.com >/dev/null ; then \
 		    git clone https://github.com/lucchouina/eppic.git eppic; \

--- a/extensions/eppic.mk
+++ b/extensions/eppic.mk
@@ -35,10 +35,10 @@ all:
           if [ -f "$(GIT)" ]; \
           then \
              if [ -n "$(EPPIC_GIT_URL)" ]; then \
-               git clone $(EPPIC_GIT_URL) eppic; \
+               git clone $(EPPIC_GIT_OPTIONS) $(EPPIC_GIT_URL) eppic; \
              else \
 	          if ping -c 1 -W 5 github.com >/dev/null ; then \
-		    git clone https://github.com/lucchouina/eppic.git eppic; \
+		    git clone $(EPPIC_GIT_OPTIONS) https://github.com/lucchouina/eppic.git eppic; \
 	          fi; \
              fi; \
           else \


### PR DESCRIPTION
Made significant changes and fixes to eppic.
Using options in the clone command break due to args parsing. need to remove the double quotes for the actual pull call.