### PR TITLE
arm64: Support overflow stack panic

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -3218,6 +3218,7 @@ typedef signed int s32;
 #define UNW_4_14      (0x200)
 #define FLIPPED_VM    (0x400)
 #define HAS_PHYSVIRT_OFFSET (0x800)
+#define OVERFLOW_STACKS     (0x1000)
 
 /*
  * Get kimage_voffset from /dev/crash
@@ -3260,6 +3261,7 @@ typedef signed int s32;
 
 #define ARM64_STACK_SIZE   (16384)
 #define ARM64_IRQ_STACK_SIZE   ARM64_STACK_SIZE
+#define ARM64_OVERFLOW_STACK_SIZE   (4096)
 
 #define _SECTION_SIZE_BITS           30
 #define _SECTION_SIZE_BITS_5_12      27
@@ -3332,6 +3334,9 @@ struct machine_specific {
 	char  *irq_stackbuf;
 	ulong __irqentry_text_start;
 	ulong __irqentry_text_end;
+	ulong overflow_stack_size;
+	ulong *overflow_stacks;
+	char  *overflow_stackbuf;
 	/* for exception vector code */
 	ulong exp_entry1_start;
 	ulong exp_entry1_end;
@@ -5770,6 +5775,7 @@ ulong cpu_map_addr(const char *type);
 #define BT_CPUMASK        (0x1000000000000ULL)
 #define BT_SHOW_ALL_REGS  (0x2000000000000ULL)
 #define BT_REGS_NOT_FOUND (0x4000000000000ULL)
+#define BT_OVERFLOW_STACK (0x8000000000000ULL)
 #define BT_SYMBOL_OFFSET   (BT_SYMBOLIC_ARGS)
 
 #define BT_REF_HEXVAL         (0x1)


### PR DESCRIPTION
Overflow stack supported since kernel 4.14 in commit 872d8327ce8,
without this patch, bt command trigger a SIGSEGV fault due the SP
pointed to the overflow stack which not yet loaded by crash.

Before:

      KERNEL: ../vmlinux
    DUMPFILE: la_guestdump.gcore
        CPUS: 8
        DATE: Tue Jul 13 19:59:44 CST 2021
      UPTIME: 00:00:42
LOAD AVERAGE: 3.99, 1.13, 0.39
       TASKS: 1925
    NODENAME: localhost
     RELEASE: 4.14.156+
     VERSION: #1 SMP PREEMPT Tue Jul 13 10:37:23 UTC 2021
     MACHINE: aarch64  (unknown Mhz)
      MEMORY: 8.7 GB
       PANIC: "Kernel panic - not syncing: kernel stack overflow"
         PID: 1969
     COMMAND: "irq/139-0-0024"
        TASK: ffffffcc1a230000  [THREAD_INFO: ffffffcc1a230000]
         CPU: 0
       STATE: TASK_RUNNING (PANIC)

crash-7.3.0> bt
PID: 1969   TASK: ffffffcc1a230000  CPU: 0   COMMAND: "irq/139-0-0024"
Segmentation fault (core dumped)

After:

crash> bt
PID: 1969   TASK: ffffffcc1a230000  CPU: 0   COMMAND: "irq/139-0-0024"
  #0 [ffffffcc7fd5cf50] __delay at ffffff8008c80774
  #1 [ffffffcc7fd5cf60] __const_udelay at ffffff8008c80864
  #2 [ffffffcc7fd5cf80] msm_trigger_wdog_bite at ffffff80084e9430
  #3 [ffffffcc7fd5cfa0] do_vm_restart at ffffff80087bc974
  #4 [ffffffcc7fd5cfc0] machine_restart at ffffff80080856fc
  #5 [ffffffcc7fd5cfd0] emergency_restart at ffffff80080d49bc
  #6 [ffffffcc7fd5d140] panic at ffffff80080af4c0
  #7 [ffffffcc7fd5d150] nmi_panic at ffffff80080af150
  #8 [ffffffcc7fd5d190] handle_bad_stack at ffffff800808b0b8
  #9 [ffffffcc7fd5d2d0] __bad_stack at ffffff800808285c
--- <IRQ stack> ---
 #10 [ffffff801187bc60] el1_error_invalid at ffffff8008082e7c
 #11 [ffffff801187bcc0] cyttsp6_mt_attention at ffffff8000e8498c [cyttsp6]
 #12 [ffffff801187bd20] call_atten_cb at ffffff8000e82030 [cyttsp6]
 #13 [ffffff801187bdc0] cyttsp6_irq at ffffff8000e81e34 [cyttsp6]
 #14 [ffffff801187bdf0] irq_thread_fn at ffffff8008128dd8
 #15 [ffffff801187be50] irq_thread at ffffff8008128ca4
 #16 [ffffff801187beb0] kthread at ffffff80080d2fc4
crash>

Signed-off-by: Hong YANG <hong.yang3@nio.com>