### PR TITLE
Author: DongyueHao <dongyue.hao@unisoc.com>

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -2146,6 +2146,7 @@ struct offset_table {                    /* stash of commonly-used offsets */
 	long wait_queue_entry_private;
 	long wait_queue_head_head;
 	long wait_queue_entry_entry;
+	long cpu_id;
 };
 
 struct size_table {         /* stash of commonly-used sizes */
@@ -2310,6 +2311,7 @@ struct size_table {         /* stash of commonly-used sizes */
 	long prb_desc;
 	long wait_queue_entry;
 	long task_struct_state;
+	long cpu_id;
 };
 
 struct array_table {
@@ -5699,6 +5701,7 @@ void dump_log(int);
 #define SHOW_LOG_TEXT  (0x4)
 #define SHOW_LOG_AUDIT (0x8)
 #define SHOW_LOG_CTIME (0x10)
+#define SHOW_LOG_CPU (0x20)
 void set_cpu(int);
 void clear_machdep_cache(void);
 struct stack_hook *gather_text_list(struct bt_info *);

--- a/help.c
+++ b/help.c
@@ -3907,6 +3907,7 @@ char *help_log[] = {
 "        shown with 'set debug 1'.",
 "    -a  Dump the audit logs remaining in kernel audit buffers that have not",
 "        been copied out to the user-space audit daemon.",
+"    -C  Display the message text with the processor_id.",
 " ",        
 "\nEXAMPLES",
 "  Dump the kernel message buffer:\n",
@@ -4053,6 +4054,11 @@ char *help_log[] = {
 "    [Sat Apr  4 07:41:09 2020] last_pfn = 0x120000 max_arch_pfn = 0x400000000",
 "    [Sat Apr  4 07:41:09 2020] MTRR default type: uncachable",
 "    [Sat Apr  4 07:41:09 2020] MTRR variable ranges disabled:",
+"    ...",
+" ",
+" Display the message text with processor id:\n",
+"    %s> log -C",
+"    [    0.467730] c0 pci 0000:ff:02.0: [8086:2c10] type 00 class 0x060000",
 "    ...",
 NULL               
 };

--- a/kernel.c
+++ b/kernel.c
@@ -4998,7 +4998,7 @@ cmd_log(void)
 
 	msg_flags = 0;
 
-        while ((c = getopt(argcnt, args, "Ttdma")) != EOF) {
+        while ((c = getopt(argcnt, args, "TtdmaC")) != EOF) {
                 switch(c)
                 {
 		case 'T':
@@ -5015,6 +5015,9 @@ cmd_log(void)
                         break;
 		case 'a':
 			msg_flags |= SHOW_LOG_AUDIT;
+			break;
+		case 'C':
+			msg_flags |= SHOW_LOG_CPU;
 			break;
                 default:
                         argerrs++;
@@ -5233,7 +5236,7 @@ dump_log_entry(char *logptr, int msg_flags)
 {
 	int indent;
 	char *msg, *p;
-	uint16_t i, text_len, dict_len, level;
+	uint16_t i, text_len, dict_len, level, cpu;
 	uint64_t ts_nsec;
 	ulonglong nanos; 
 	ulong rem;
@@ -5278,6 +5281,14 @@ dump_log_entry(char *logptr, int msg_flags)
 		else
 			sprintf(buf, "[%5lld.%06ld] ", nanos, rem/1000);
 		ilen = strlen(buf);
+		fprintf(fp, "%s", buf);
+	}
+
+	cpu = USHORT(logptr + OFFSET(cpu_id));
+
+	if (msg_flags & SHOW_LOG_CPU) {
+		sprintf(buf, "c%d ", cpu);
+		ilen += strlen(buf);
 		fprintf(fp, "%s", buf);
 	}
 
@@ -5347,6 +5358,7 @@ dump_variable_length_record_log(int msg_flags)
 		MEMBER_OFFSET_INIT(log_level, log_struct_name, "level");
 		MEMBER_SIZE_INIT(log_level, log_struct_name, "level");
 		MEMBER_OFFSET_INIT(log_flags_level, log_struct_name, "flags_level");
+		MEMBER_OFFSET_INIT(cpu_id, log_struct_name, "cpu");
 			
 		/*
 		 * If things change, don't kill a dumpfile session 

--- a/symbols.c
+++ b/symbols.c
@@ -10500,6 +10500,8 @@ dump_offset_table(char *spec, ulong makestruct)
 		OFFSET(log_level));
 	fprintf(fp, "               log_flags_level: %ld\n",
 		OFFSET(log_flags_level));
+	fprintf(fp, "                        cpu_id: %ld\n",
+		OFFSET(cpu_id));
 
 	fprintf(fp, "               printk_info_seq: %ld\n", OFFSET(printk_info_seq));
 	fprintf(fp, "           printk_info_ts_nseq: %ld\n", OFFSET(printk_info_ts_nsec));
@@ -10913,6 +10915,8 @@ dump_offset_table(char *spec, ulong makestruct)
 		SIZE(log));
 	fprintf(fp, "                     log_level: %ld\n",
 		SIZE(log_level));
+	fprintf(fp, "                        cpu_id: %ld\n",
+		SIZE(cpu_id));
 	fprintf(fp, "                         rt_rq: %ld\n",
 		SIZE(rt_rq));
 	fprintf(fp, "                    task_group: %ld\n",


### PR DESCRIPTION
	Handle print message format for kernel4.14 and later

	crash> log
	[    0.000000] Linux version 4.14.193+-ab000037 (builder@ceshhud12)...

	crash> log -C
	[    0.000000] c0 Linux version 4.14.193+-ab000037 (builder@ceshhud12)...

	show the processor id for each message text when use cmd: log -C

	Signed-off-by: DongyueHao <dongyue.hao@unisoc.com>