### PR TITLE
Fix for "kmem -s|-S" on Linux 5.17.0+

### DIFF
--- a/memory.c
+++ b/memory.c
@@ -680,6 +680,8 @@ vm_init(void)
 			MEMBER_OFFSET_INIT(slab_s_mem, "slab", "s_mem");
 			MEMBER_OFFSET_INIT(slab_inuse, "slab", "inuse");
 			MEMBER_OFFSET_INIT(slab_free, "slab", "free");
+                        MEMBER_OFFSET_INIT(page_s_mem, "slab", "s_mem");
+                        MEMBER_OFFSET_INIT(page_active, "slab", "active");
 			/*
 			 *  slab members were moved to an anonymous union in 2.6.39.
 			 */
@@ -691,6 +693,10 @@ vm_init(void)
 				ANON_MEMBER_OFFSET_INIT(slab_inuse, "slab", "inuse");
 			if (INVALID_MEMBER(slab_free))
 				ANON_MEMBER_OFFSET_INIT(slab_free, "slab", "free");
+			if (INVALID_MEMBER(page_s_mem))
+				ANON_MEMBER_OFFSET_INIT(page_s_mem, "slab", "s_mem");
+			if (INVALID_MEMBER(page_active))
+				ANON_MEMBER_OFFSET_INIT(page_active, "slab", "active");
 		}
 
 		MEMBER_OFFSET_INIT(array_cache_avail, "array_cache", "avail");


### PR DESCRIPTION
Since the following kernel commits split slab info from struct page
into struct slab, crash cannot get several slab related offsets from
struct page.

  d122019bf061 ("mm: Split slab into its own type")
  401fb12c68c2 ("mm: Differentiate struct slab fields by sl*b implementations")
  07f910f9b729 ("mm: Remove slab from struct page")

Without the patch, "kmem -s|-S" options cannot work
correctly with the following errors:

  crash> kmem -s
  kmem: invalid structure member offset: page_active
        FILE: memory.c  LINE: 12225  FUNCTION: verify_slab_overload_page()

  [/usr/bin/crash] error trace: 532526 => 53353a => 5e0a6a => 5e09dc
  [Detaching after fork from child process 28299]

    5e09dc: OFFSET_verify.part.36+92
  [Detaching after fork from child process 28301]
    5e0a6a: OFFSET_verify+58
  [Detaching after fork from child process 28303]
    53353a: verify_slab_overload_page+588
  [Detaching after fork from child process 28305]
    532526: do_slab_chain_slab_overload_page+1171

  kmem: invalid structure member offset: page_active
        FILE: memory.c  LINE: 12225  FUNCTION: verify_slab_overload_page()

Signed-off-by: xiaer1921 <xiaer1921@gmail.com>