### PR TITLE
Fix C99 compatibility issues in embedded copy of GDB

### DIFF
--- a/gdb-10.2.patch
+++ b/gdb-10.2.patch
@@ -12,7 +12,14 @@ tar xvzmf gdb-10.2.tar.gz \
 	gdb-10.2/gdb/symtab.c \
 	gdb-10.2/gdb/printcmd.c \
 	gdb-10.2/gdb/symfile.c \
-	gdb-10.2/gdb/Makefile.in
+	gdb-10.2/gdb/Makefile.in \
+	gdb-10.2/bfd/elf-bfd.h \
+	gdb-10.2/gnulib/import/cdefs.h \
+	gdb-10.2/libiberty/aclocal.m4 \
+	gdb-10.2/libiberty/configure \
+	gdb-10.2/readline/readline/aclocal.m4 \
+	gdb-10.2/readline/readline/configure \
+	gdb-10.2/readline/readline/configure.ac \
 
 exit 0
 
@@ -2078,3 +2085,1013 @@ exit 0
  
    return new_type;
  }
+diff --git gdb-10.2.orig/bfd/elf-bfd.h gdb-10.2/bfd/elf-bfd.h
+index eebdf9a..775d96c 100644
+--- gdb-10.2.orig/bfd/elf-bfd.h
++++ gdb-10.2/bfd/elf-bfd.h
+@@ -27,6 +27,8 @@
+ #include "elf/internal.h"
+ #include "bfdlink.h"
+ 
++#include <string.h>
++
+ #ifdef __cplusplus
+ extern "C" {
+ #endif
+diff --git gdb-10.2.orig/gnulib/import/cdefs.h gdb-10.2/gnulib/import/cdefs.h
+index d8e4a00..c37a3ff 100644
+--- gdb-10.2.orig/gnulib/import/cdefs.h
++++ gdb-10.2/gnulib/import/cdefs.h
+@@ -1,17 +1,18 @@
+-/* Copyright (C) 1992-2020 Free Software Foundation, Inc.
++/* Copyright (C) 1992-2023 Free Software Foundation, Inc.
++   Copyright The GNU Toolchain Authors.
+    This file is part of the GNU C Library.
+ 
+    The GNU C Library is free software; you can redistribute it and/or
+-   modify it under the terms of the GNU General Public
++   modify it under the terms of the GNU Lesser General Public
+    License as published by the Free Software Foundation; either
+-   version 3 of the License, or (at your option) any later version.
++   version 2.1 of the License, or (at your option) any later version.
+ 
+    The GNU C Library is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+-   General Public License for more details.
++   Lesser General Public License for more details.
+ 
+-   You should have received a copy of the GNU General Public
++   You should have received a copy of the GNU Lesser General Public
+    License along with the GNU C Library; if not, see
+    <https://www.gnu.org/licenses/>.  */
+ 
+@@ -25,16 +26,38 @@
+ 
+ /* The GNU libc does not support any K&R compilers or the traditional mode
+    of ISO C compilers anymore.  Check for some of the combinations not
+-   anymore supported.  */
+-#if defined __GNUC__ && !defined __STDC__
+-# error "You need a ISO C conforming compiler to use the glibc headers"
++   supported anymore.  */
++#if defined __GNUC__ && !defined __STDC__ && !defined __cplusplus
++# error "You need a ISO C or C++ conforming compiler to use the glibc headers"
+ #endif
+ 
+ /* Some user header file might have defined this before.  */
+ #undef	__P
+ #undef	__PMT
+ 
+-#ifdef __GNUC__
++/* Compilers that lack __has_attribute may object to
++       #if defined __has_attribute && __has_attribute (...)
++   even though they do not need to evaluate the right-hand side of the &&.
++   Similarly for __has_builtin, etc.  */
++#if (defined __has_attribute \
++     && (!defined __clang_minor__ \
++         || 3 < __clang_major__ + (5 <= __clang_minor__)))
++# define __glibc_has_attribute(attr) __has_attribute (attr)
++#else
++# define __glibc_has_attribute(attr) 0
++#endif
++#ifdef __has_builtin
++# define __glibc_has_builtin(name) __has_builtin (name)
++#else
++# define __glibc_has_builtin(name) 0
++#endif
++#ifdef __has_extension
++# define __glibc_has_extension(ext) __has_extension (ext)
++#else
++# define __glibc_has_extension(ext) 0
++#endif
++
++#if defined __GNUC__ || defined __clang__
+ 
+ /* All functions, except those with callbacks or those that
+    synchronize memory, are leaf functions.  */
+@@ -47,21 +70,26 @@
+ # endif
+ 
+ /* GCC can always grok prototypes.  For C++ programs we add throw()
+-   to help it optimize the function calls.  But this works only with
+-   gcc 2.8.x and egcs.  For gcc 3.2 and up we even mark C functions
++   to help it optimize the function calls.  But this only works with
++   gcc 2.8.x and egcs.  For gcc 3.4 and up we even mark C functions
+    as non-throwing using a function attribute since programs can use
+    the -fexceptions options for C code as well.  */
+-# if !defined __cplusplus && __GNUC_PREREQ (3, 3)
++# if !defined __cplusplus \
++     && (__GNUC_PREREQ (3, 4) || __glibc_has_attribute (__nothrow__))
+ #  define __THROW	__attribute__ ((__nothrow__ __LEAF))
+ #  define __THROWNL	__attribute__ ((__nothrow__))
+ #  define __NTH(fct)	__attribute__ ((__nothrow__ __LEAF)) fct
+ #  define __NTHNL(fct)  __attribute__ ((__nothrow__)) fct
+ # else
+-#  if defined __cplusplus && __GNUC_PREREQ (2,8)
+-#   define __THROW	throw ()
+-#   define __THROWNL	throw ()
+-#   define __NTH(fct)	__LEAF_ATTR fct throw ()
+-#   define __NTHNL(fct) fct throw ()
++#  if defined __cplusplus && (__GNUC_PREREQ (2,8) || __clang_major >= 4)
++#   if __cplusplus >= 201103L
++#    define __THROW	noexcept (true)
++#   else
++#    define __THROW	throw ()
++#   endif
++#   define __THROWNL	__THROW
++#   define __NTH(fct)	__LEAF_ATTR fct __THROW
++#   define __NTHNL(fct) fct __THROW
+ #  else
+ #   define __THROW
+ #   define __THROWNL
+@@ -70,7 +98,7 @@
+ #  endif
+ # endif
+ 
+-#else	/* Not GCC.  */
++#else	/* Not GCC or clang.  */
+ 
+ # if (defined __cplusplus						\
+       || (defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L))
+@@ -83,16 +111,7 @@
+ # define __THROWNL
+ # define __NTH(fct)	fct
+ 
+-#endif	/* GCC.  */
+-
+-/* Compilers that are not clang may object to
+-       #if defined __clang__ && __has_extension(...)
+-   even though they do not need to evaluate the right-hand side of the &&.  */
+-#if defined __clang__ && defined __has_extension
+-# define __glibc_clang_has_extension(ext) __has_extension (ext)
+-#else
+-# define __glibc_clang_has_extension(ext) 0
+-#endif
++#endif	/* GCC || clang.  */
+ 
+ /* These two macros are not used in glibc anymore.  They are kept here
+    only because some other projects expect the macros to be defined.  */
+@@ -123,14 +142,70 @@
+ #define __bos(ptr) __builtin_object_size (ptr, __USE_FORTIFY_LEVEL > 1)
+ #define __bos0(ptr) __builtin_object_size (ptr, 0)
+ 
++/* Use __builtin_dynamic_object_size at _FORTIFY_SOURCE=3 when available.  */
++#if __USE_FORTIFY_LEVEL == 3 && (__glibc_clang_prereq (9, 0)		      \
++				 || __GNUC_PREREQ (12, 0))
++# define __glibc_objsize0(__o) __builtin_dynamic_object_size (__o, 0)
++# define __glibc_objsize(__o) __builtin_dynamic_object_size (__o, 1)
++#else
++# define __glibc_objsize0(__o) __bos0 (__o)
++# define __glibc_objsize(__o) __bos (__o)
++#endif
++
++#if __USE_FORTIFY_LEVEL > 0
++/* Compile time conditions to choose between the regular, _chk and _chk_warn
++   variants.  These conditions should get evaluated to constant and optimized
++   away.  */
++
++#define __glibc_safe_len_cond(__l, __s, __osz) ((__l) <= (__osz) / (__s))
++#define __glibc_unsigned_or_positive(__l) \
++  ((__typeof (__l)) 0 < (__typeof (__l)) -1				      \
++   || (__builtin_constant_p (__l) && (__l) > 0))
++
++/* Length is known to be safe at compile time if the __L * __S <= __OBJSZ
++   condition can be folded to a constant and if it is true, or unknown (-1) */
++#define __glibc_safe_or_unknown_len(__l, __s, __osz) \
++  ((__builtin_constant_p (__osz) && (__osz) == (__SIZE_TYPE__) -1)	      \
++   || (__glibc_unsigned_or_positive (__l)				      \
++       && __builtin_constant_p (__glibc_safe_len_cond ((__SIZE_TYPE__) (__l), \
++						       (__s), (__osz)))	      \
++       && __glibc_safe_len_cond ((__SIZE_TYPE__) (__l), (__s), (__osz))))
++
++/* Conversely, we know at compile time that the length is unsafe if the
++   __L * __S <= __OBJSZ condition can be folded to a constant and if it is
++   false.  */
++#define __glibc_unsafe_len(__l, __s, __osz) \
++  (__glibc_unsigned_or_positive (__l)					      \
++   && __builtin_constant_p (__glibc_safe_len_cond ((__SIZE_TYPE__) (__l),     \
++						   __s, __osz))		      \
++   && !__glibc_safe_len_cond ((__SIZE_TYPE__) (__l), __s, __osz))
++
++/* Fortify function f.  __f_alias, __f_chk and __f_chk_warn must be
++   declared.  */
++
++#define __glibc_fortify(f, __l, __s, __osz, ...) \
++  (__glibc_safe_or_unknown_len (__l, __s, __osz)			      \
++   ? __ ## f ## _alias (__VA_ARGS__)					      \
++   : (__glibc_unsafe_len (__l, __s, __osz)				      \
++      ? __ ## f ## _chk_warn (__VA_ARGS__, __osz)			      \
++      : __ ## f ## _chk (__VA_ARGS__, __osz)))
++
++/* Fortify function f, where object size argument passed to f is the number of
++   elements and not total size.  */
++
++#define __glibc_fortify_n(f, __l, __s, __osz, ...) \
++  (__glibc_safe_or_unknown_len (__l, __s, __osz)			      \
++   ? __ ## f ## _alias (__VA_ARGS__)					      \
++   : (__glibc_unsafe_len (__l, __s, __osz)				      \
++      ? __ ## f ## _chk_warn (__VA_ARGS__, (__osz) / (__s))		      \
++      : __ ## f ## _chk (__VA_ARGS__, (__osz) / (__s))))
++#endif
++
+ #if __GNUC_PREREQ (4,3)
+-# define __warndecl(name, msg) \
+-  extern void name (void) __attribute__((__warning__ (msg)))
+ # define __warnattr(msg) __attribute__((__warning__ (msg)))
+ # define __errordecl(name, msg) \
+   extern void name (void) __attribute__((__error__ (msg)))
+ #else
+-# define __warndecl(name, msg) extern void name (void)
+ # define __warnattr(msg)
+ # define __errordecl(name, msg) extern void name (void)
+ #endif
+@@ -142,8 +217,8 @@
+ #if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L && !defined __HP_cc
+ # define __flexarr	[]
+ # define __glibc_c99_flexarr_available 1
+-#elif __GNUC_PREREQ (2,97)
+-/* GCC 2.97 supports C99 flexible array members as an extension,
++#elif __GNUC_PREREQ (2,97) || defined __clang__
++/* GCC 2.97 and clang support C99 flexible array members as an extension,
+    even when in C89 mode or compiling C++ (any version).  */
+ # define __flexarr	[]
+ # define __glibc_c99_flexarr_available 1
+@@ -169,7 +244,7 @@
+    Example:
+    int __REDIRECT(setpgrp, (__pid_t pid, __pid_t pgrp), setpgid); */
+ 
+-#if defined __GNUC__ && __GNUC__ >= 2
++#if (defined __GNUC__ && __GNUC__ >= 2) || (__clang_major__ >= 4)
+ 
+ # define __REDIRECT(name, proto, alias) name proto __asm__ (__ASMNAME (#alias))
+ # ifdef __cplusplus
+@@ -194,17 +269,17 @@
+ */
+ #endif
+ 
+-/* GCC has various useful declarations that can be made with the
+-   `__attribute__' syntax.  All of the ways we use this do fine if
+-   they are omitted for compilers that don't understand it. */
+-#if !defined __GNUC__ || __GNUC__ < 2
++/* GCC and clang have various useful declarations that can be made with
++   the '__attribute__' syntax.  All of the ways we use this do fine if
++   they are omitted for compilers that don't understand it.  */
++#if !(defined __GNUC__ || defined __clang__)
+ # define __attribute__(xyz)	/* Ignore */
+ #endif
+ 
+ /* At some point during the gcc 2.96 development the `malloc' attribute
+    for functions was introduced.  We don't want to use it unconditionally
+    (although this would be possible) since it generates warnings.  */
+-#if __GNUC_PREREQ (2,96)
++#if __GNUC_PREREQ (2,96) || __glibc_has_attribute (__malloc__)
+ # define __attribute_malloc__ __attribute__ ((__malloc__))
+ #else
+ # define __attribute_malloc__ /* Ignore */
+@@ -219,26 +294,41 @@
+ # define __attribute_alloc_size__(params) /* Ignore.  */
+ #endif
+ 
++/* Tell the compiler which argument to an allocation function
++   indicates the alignment of the allocation.  */
++#if __GNUC_PREREQ (4, 9) || __glibc_has_attribute (__alloc_align__)
++# define __attribute_alloc_align__(param) \
++  __attribute__ ((__alloc_align__ param))
++#else
++# define __attribute_alloc_align__(param) /* Ignore.  */
++#endif
++
+ /* At some point during the gcc 2.96 development the `pure' attribute
+    for functions was introduced.  We don't want to use it unconditionally
+    (although this would be possible) since it generates warnings.  */
+-#if __GNUC_PREREQ (2,96)
++#if __GNUC_PREREQ (2,96) || __glibc_has_attribute (__pure__)
+ # define __attribute_pure__ __attribute__ ((__pure__))
+ #else
+ # define __attribute_pure__ /* Ignore */
+ #endif
+ 
+ /* This declaration tells the compiler that the value is constant.  */
+-#if __GNUC_PREREQ (2,5)
++#if __GNUC_PREREQ (2,5) || __glibc_has_attribute (__const__)
+ # define __attribute_const__ __attribute__ ((__const__))
+ #else
+ # define __attribute_const__ /* Ignore */
+ #endif
+ 
++#if __GNUC_PREREQ (2,7) || __glibc_has_attribute (__unused__)
++# define __attribute_maybe_unused__ __attribute__ ((__unused__))
++#else
++# define __attribute_maybe_unused__ /* Ignore */
++#endif
++
+ /* At some point during the gcc 3.1 development the `used' attribute
+    for functions was introduced.  We don't want to use it unconditionally
+    (although this would be possible) since it generates warnings.  */
+-#if __GNUC_PREREQ (3,1)
++#if __GNUC_PREREQ (3,1) || __glibc_has_attribute (__used__)
+ # define __attribute_used__ __attribute__ ((__used__))
+ # define __attribute_noinline__ __attribute__ ((__noinline__))
+ #else
+@@ -247,7 +337,7 @@
+ #endif
+ 
+ /* Since version 3.2, gcc allows marking deprecated functions.  */
+-#if __GNUC_PREREQ (3,2)
++#if __GNUC_PREREQ (3,2) || __glibc_has_attribute (__deprecated__)
+ # define __attribute_deprecated__ __attribute__ ((__deprecated__))
+ #else
+ # define __attribute_deprecated__ /* Ignore */
+@@ -256,8 +346,8 @@
+ /* Since version 4.5, gcc also allows one to specify the message printed
+    when a deprecated function is used.  clang claims to be gcc 4.2, but
+    may also support this feature.  */
+-#if __GNUC_PREREQ (4,5) || \
+-    __glibc_clang_has_extension (__attribute_deprecated_with_message__)
++#if __GNUC_PREREQ (4,5) \
++    || __glibc_has_extension (__attribute_deprecated_with_message__)
+ # define __attribute_deprecated_msg__(msg) \
+ 	 __attribute__ ((__deprecated__ (msg)))
+ #else
+@@ -270,7 +360,7 @@
+    If several `format_arg' attributes are given for the same function, in
+    gcc-3.0 and older, all but the last one are ignored.  In newer gccs,
+    all designated arguments are considered.  */
+-#if __GNUC_PREREQ (2,8)
++#if __GNUC_PREREQ (2,8) || __glibc_has_attribute (__format_arg__)
+ # define __attribute_format_arg__(x) __attribute__ ((__format_arg__ (x)))
+ #else
+ # define __attribute_format_arg__(x) /* Ignore */
+@@ -280,7 +370,7 @@
+    attribute for functions was introduced.  We don't want to use it
+    unconditionally (although this would be possible) since it
+    generates warnings.  */
+-#if __GNUC_PREREQ (2,97)
++#if __GNUC_PREREQ (2,97) || __glibc_has_attribute (__format__)
+ # define __attribute_format_strfmon__(a,b) \
+   __attribute__ ((__format__ (__strfmon__, a, b)))
+ #else
+@@ -288,19 +378,33 @@
+ #endif
+ 
+ /* The nonnull function attribute marks pointer parameters that
+-   must not be NULL.  Do not define __nonnull if it is already defined,
+-   for portability when this file is used in Gnulib.  */
++   must not be NULL.  This has the name __nonnull in glibc,
++   and __attribute_nonnull__ in files shared with Gnulib to avoid
++   collision with a different __nonnull in DragonFlyBSD 5.9.  */
++#ifndef __attribute_nonnull__
++# if __GNUC_PREREQ (3,3) || __glibc_has_attribute (__nonnull__)
++#  define __attribute_nonnull__(params) __attribute__ ((__nonnull__ params))
++# else
++#  define __attribute_nonnull__(params)
++# endif
++#endif
+ #ifndef __nonnull
+-# if __GNUC_PREREQ (3,3)
+-#  define __nonnull(params) __attribute__ ((__nonnull__ params))
++# define __nonnull(params) __attribute_nonnull__ (params)
++#endif
++
++/* The returns_nonnull function attribute marks the return type of the function
++   as always being non-null.  */
++#ifndef __returns_nonnull
++# if __GNUC_PREREQ (4, 9) || __glibc_has_attribute (__returns_nonnull__)
++# define __returns_nonnull __attribute__ ((__returns_nonnull__))
+ # else
+-#  define __nonnull(params)
++# define __returns_nonnull
+ # endif
+ #endif
+ 
+ /* If fortification mode, we warn about unused results of certain
+    function calls which can lead to problems.  */
+-#if __GNUC_PREREQ (3,4)
++#if __GNUC_PREREQ (3,4) || __glibc_has_attribute (__warn_unused_result__)
+ # define __attribute_warn_unused_result__ \
+    __attribute__ ((__warn_unused_result__))
+ # if defined __USE_FORTIFY_LEVEL && __USE_FORTIFY_LEVEL > 0
+@@ -314,7 +418,7 @@
+ #endif
+ 
+ /* Forces a function to be always inlined.  */
+-#if __GNUC_PREREQ (3,2)
++#if __GNUC_PREREQ (3,2) || __glibc_has_attribute (__always_inline__)
+ /* The Linux kernel defines __always_inline in stddef.h (283d7573), and
+    it conflicts with this definition.  Therefore undefine it first to
+    allow either header to be included first.  */
+@@ -327,7 +431,7 @@
+ 
+ /* Associate error messages with the source location of the call site rather
+    than with the source location inside the function.  */
+-#if __GNUC_PREREQ (4,3)
++#if __GNUC_PREREQ (4,3) || __glibc_has_attribute (__artificial__)
+ # define __attribute_artificial__ __attribute__ ((__artificial__))
+ #else
+ # define __attribute_artificial__ /* Ignore */
+@@ -370,12 +474,14 @@
+    run in pedantic mode if the uses are carefully marked using the
+    `__extension__' keyword.  But this is not generally available before
+    version 2.8.  */
+-#if !__GNUC_PREREQ (2,8)
++#if !(__GNUC_PREREQ (2,8) || defined __clang__)
+ # define __extension__		/* Ignore */
+ #endif
+ 
+-/* __restrict is known in EGCS 1.2 and above. */
+-#if !__GNUC_PREREQ (2,92)
++/* __restrict is known in EGCS 1.2 and above, and in clang.
++   It works also in C++ mode (outside of arrays), but only when spelled
++   as '__restrict', not 'restrict'.  */
++#if !(__GNUC_PREREQ (2,92) || __clang_major__ >= 3)
+ # if defined __STDC_VERSION__ && __STDC_VERSION__ >= 199901L
+ #  define __restrict	restrict
+ # else
+@@ -385,8 +491,9 @@
+ 
+ /* ISO C99 also allows to declare arrays as non-overlapping.  The syntax is
+      array_name[restrict]
+-   GCC 3.1 supports this.  */
+-#if __GNUC_PREREQ (3,1) && !defined __GNUG__
++   GCC 3.1 and clang support this.
++   This syntax is not usable in C++ mode.  */
++#if (__GNUC_PREREQ (3,1) || __clang_major__ >= 3) && !defined __cplusplus
+ # define __restrict_arr	__restrict
+ #else
+ # ifdef __GNUC__
+@@ -401,7 +508,7 @@
+ # endif
+ #endif
+ 
+-#if __GNUC__ >= 3
++#if (__GNUC__ >= 3) || __glibc_has_builtin (__builtin_expect)
+ # define __glibc_unlikely(cond)	__builtin_expect ((cond), 0)
+ # define __glibc_likely(cond)	__builtin_expect ((cond), 1)
+ #else
+@@ -409,15 +516,10 @@
+ # define __glibc_likely(cond)	(cond)
+ #endif
+ 
+-#ifdef __has_attribute
+-# define __glibc_has_attribute(attr)	__has_attribute (attr)
+-#else
+-# define __glibc_has_attribute(attr)	0
+-#endif
+-
+ #if (!defined _Noreturn \
+      && (defined __STDC_VERSION__ ? __STDC_VERSION__ : 0) < 201112 \
+-     &&  !__GNUC_PREREQ (4,7))
++     &&  !(__GNUC_PREREQ (4,7) \
++           || (3 < __clang_major__ + (5 <= __clang_minor__))))
+ # if __GNUC_PREREQ (2,8)
+ #  define _Noreturn __attribute__ ((__noreturn__))
+ # else
+@@ -434,22 +536,63 @@
+ # define __attribute_nonstring__
+ #endif
+ 
++/* Undefine (also defined in libc-symbols.h).  */
++#undef __attribute_copy__
++#if __GNUC_PREREQ (9, 0)
++/* Copies attributes from the declaration or type referenced by
++   the argument.  */
++# define __attribute_copy__(arg) __attribute__ ((__copy__ (arg)))
++#else
++# define __attribute_copy__(arg)
++#endif
++
+ #if (!defined _Static_assert && !defined __cplusplus \
+      && (defined __STDC_VERSION__ ? __STDC_VERSION__ : 0) < 201112 \
+-     && (!__GNUC_PREREQ (4, 6) || defined __STRICT_ANSI__))
++     && (!(__GNUC_PREREQ (4, 6) || __clang_major__ >= 4) \
++         || defined __STRICT_ANSI__))
+ # define _Static_assert(expr, diagnostic) \
+     extern int (*__Static_assert_function (void)) \
+       [!!sizeof (struct { int __error_if_negative: (expr) ? 2 : -1; })]
+ #endif
+ 
+-/* The #ifndef lets Gnulib avoid including these on non-glibc
+-   platforms, where the includes typically do not exist.  */
+-#ifndef __WORDSIZE
++/* Gnulib avoids including these, as they don't work on non-glibc or
++   older glibc platforms.  */
++#ifndef __GNULIB_CDEFS
+ # include <bits/wordsize.h>
+ # include <bits/long-double.h>
+ #endif
+ 
+-#if defined __LONG_DOUBLE_MATH_OPTIONAL && defined __NO_LONG_DOUBLE_MATH
++#if __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI == 1
++# ifdef __REDIRECT
++
++/* Alias name defined automatically.  */
++#  define __LDBL_REDIR(name, proto) ... unused__ldbl_redir
++#  define __LDBL_REDIR_DECL(name) \
++  extern __typeof (name) name __asm (__ASMNAME ("__" #name "ieee128"));
++
++/* Alias name defined automatically, with leading underscores.  */
++#  define __LDBL_REDIR2_DECL(name) \
++  extern __typeof (__##name) __##name \
++    __asm (__ASMNAME ("__" #name "ieee128"));
++
++/* Alias name defined manually.  */
++#  define __LDBL_REDIR1(name, proto, alias) ... unused__ldbl_redir1
++#  define __LDBL_REDIR1_DECL(name, alias) \
++  extern __typeof (name) name __asm (__ASMNAME (#alias));
++
++#  define __LDBL_REDIR1_NTH(name, proto, alias) \
++  __REDIRECT_NTH (name, proto, alias)
++#  define __REDIRECT_NTH_LDBL(name, proto, alias) \
++  __LDBL_REDIR1_NTH (name, proto, __##alias##ieee128)
++
++/* Unused.  */
++#  define __REDIRECT_LDBL(name, proto, alias) ... unused__redirect_ldbl
++#  define __LDBL_REDIR_NTH(name, proto) ... unused__ldbl_redir_nth
++
++# else
++_Static_assert (0, "IEEE 128-bits long double requires redirection on this platform");
++# endif
++#elif defined __LONG_DOUBLE_MATH_OPTIONAL && defined __NO_LONG_DOUBLE_MATH
+ # define __LDBL_COMPAT 1
+ # ifdef __REDIRECT
+ #  define __LDBL_REDIR1(name, proto, alias) __REDIRECT (name, proto, alias)
+@@ -458,6 +601,8 @@
+ #  define __LDBL_REDIR1_NTH(name, proto, alias) __REDIRECT_NTH (name, proto, alias)
+ #  define __LDBL_REDIR_NTH(name, proto) \
+   __LDBL_REDIR1_NTH (name, proto, __nldbl_##name)
++#  define __LDBL_REDIR2_DECL(name) \
++  extern __typeof (__##name) __##name __asm (__ASMNAME ("__nldbl___" #name));
+ #  define __LDBL_REDIR1_DECL(name, alias) \
+   extern __typeof (name) name __asm (__ASMNAME (#alias));
+ #  define __LDBL_REDIR_DECL(name) \
+@@ -468,11 +613,13 @@
+   __LDBL_REDIR1_NTH (name, proto, __nldbl_##alias)
+ # endif
+ #endif
+-#if !defined __LDBL_COMPAT || !defined __REDIRECT
++#if (!defined __LDBL_COMPAT && __LDOUBLE_REDIRECTS_TO_FLOAT128_ABI == 0) \
++    || !defined __REDIRECT
+ # define __LDBL_REDIR1(name, proto, alias) name proto
+ # define __LDBL_REDIR(name, proto) name proto
+ # define __LDBL_REDIR1_NTH(name, proto, alias) name proto __THROW
+ # define __LDBL_REDIR_NTH(name, proto) name proto __THROW
++# define __LDBL_REDIR2_DECL(name)
+ # define __LDBL_REDIR_DECL(name)
+ # ifdef __REDIRECT
+ #  define __REDIRECT_LDBL(name, proto, alias) __REDIRECT (name, proto, alias)
+@@ -503,7 +650,7 @@
+    check is required to enable the use of generic selection.  */
+ #if !defined __cplusplus \
+     && (__GNUC_PREREQ (4, 9) \
+-	|| __glibc_clang_has_extension (c_generic_selections) \
++	|| __glibc_has_extension (c_generic_selections) \
+ 	|| (!defined __GNUC__ && defined __STDC_VERSION__ \
+ 	    && __STDC_VERSION__ >= 201112L))
+ # define __HAVE_GENERIC_SELECTION 1
+@@ -511,4 +658,50 @@
+ # define __HAVE_GENERIC_SELECTION 0
+ #endif
+ 
++#if __GNUC_PREREQ (10, 0)
++/* Designates a 1-based positional argument ref-index of pointer type
++   that can be used to access size-index elements of the pointed-to
++   array according to access mode, or at least one element when
++   size-index is not provided:
++     access (access-mode, <ref-index> [, <size-index>])  */
++#  define __attr_access(x) __attribute__ ((__access__ x))
++/* For _FORTIFY_SOURCE == 3 we use __builtin_dynamic_object_size, which may
++   use the access attribute to get object sizes from function definition
++   arguments, so we can't use them on functions we fortify.  Drop the object
++   size hints for such functions.  */
++#  if __USE_FORTIFY_LEVEL == 3
++#    define __fortified_attr_access(a, o, s) __attribute__ ((__access__ (a, o)))
++#  else
++#    define __fortified_attr_access(a, o, s) __attr_access ((a, o, s))
++#  endif
++#  if __GNUC_PREREQ (11, 0)
++#    define __attr_access_none(argno) __attribute__ ((__access__ (__none__, argno)))
++#  else
++#    define __attr_access_none(argno)
++#  endif
++#else
++#  define __fortified_attr_access(a, o, s)
++#  define __attr_access(x)
++#  define __attr_access_none(argno)
++#endif
++
++#if __GNUC_PREREQ (11, 0)
++/* Designates dealloc as a function to call to deallocate objects
++   allocated by the declared function.  */
++# define __attr_dealloc(dealloc, argno) \
++    __attribute__ ((__malloc__ (dealloc, argno)))
++# define __attr_dealloc_free __attr_dealloc (__builtin_free, 1)
++#else
++# define __attr_dealloc(dealloc, argno)
++# define __attr_dealloc_free
++#endif
++
++/* Specify that a function such as setjmp or vfork may return
++   twice.  */
++#if __GNUC_PREREQ (4, 1)
++# define __attribute_returns_twice__ __attribute__ ((__returns_twice__))
++#else
++# define __attribute_returns_twice__ /* Ignore.  */
++#endif
++
+ #endif	 /* sys/cdefs.h */
+diff --git gdb-10.2.orig/libiberty/aclocal.m4 gdb-10.2/libiberty/aclocal.m4
+index 34c0a5b..0e91b90 100644
+--- gdb-10.2.orig/libiberty/aclocal.m4
++++ gdb-10.2/libiberty/aclocal.m4
+@@ -16,6 +16,8 @@ AC_CACHE_CHECK([for working strncmp], ac_cv_func_strncmp_works,
+ [AC_TRY_RUN([
+ /* Test by Jim Wilson and Kaveh Ghazi.
+    Check whether strncmp reads past the end of its string parameters. */
++#include <stdlib.h>
++#include <string.h>
+ #include <sys/types.h>
+ 
+ #ifdef HAVE_FCNTL_H
+@@ -43,7 +45,8 @@ AC_CACHE_CHECK([for working strncmp], ac_cv_func_strncmp_works,
+ 
+ #define MAP_LEN 0x10000
+ 
+-main ()
++int
++main (void)
+ {
+ #if defined(HAVE_MMAP) || defined(HAVE_MMAP_ANYWHERE)
+   char *p;
+@@ -149,7 +152,10 @@ if test $ac_cv_os_cray = yes; then
+ fi
+ 
+ AC_CACHE_CHECK(stack direction for C alloca, ac_cv_c_stack_direction,
+-[AC_TRY_RUN([find_stack_direction ()
++[AC_TRY_RUN([#include <stdlib.h>
++
++int
++find_stack_direction (void)
+ {
+   static char *addr = 0;
+   auto char dummy;
+@@ -161,7 +167,9 @@ AC_CACHE_CHECK(stack direction for C alloca, ac_cv_c_stack_direction,
+   else
+     return (&dummy > addr) ? 1 : -1;
+ }
+-main ()
++
++int
++main (void)
+ {
+   exit (find_stack_direction() < 0);
+ }], 
+diff --git gdb-10.2.orig/libiberty/configure gdb-10.2/libiberty/configure
+index ff93c9e..2b880a8 100755
+--- gdb-10.2.orig/libiberty/configure
++++ gdb-10.2/libiberty/configure
+@@ -6724,7 +6724,10 @@ else
+ else
+   cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+-find_stack_direction ()
++#include <stdlib.h>
++
++int
++find_stack_direction (void)
+ {
+   static char *addr = 0;
+   auto char dummy;
+@@ -6736,7 +6739,9 @@ find_stack_direction ()
+   else
+     return (&dummy > addr) ? 1 : -1;
+ }
+-main ()
++
++int
++main (void)
+ {
+   exit (find_stack_direction() < 0);
+ }
+@@ -7557,6 +7562,8 @@ else
+ 
+ /* Test by Jim Wilson and Kaveh Ghazi.
+    Check whether strncmp reads past the end of its string parameters. */
++#include <stdlib.h>
++#include <string.h>
+ #include <sys/types.h>
+ 
+ #ifdef HAVE_FCNTL_H
+@@ -7584,7 +7591,8 @@ else
+ 
+ #define MAP_LEN 0x10000
+ 
+-main ()
++int
++main (void)
+ {
+ #if defined(HAVE_MMAP) || defined(HAVE_MMAP_ANYWHERE)
+   char *p;
+diff --git gdb-10.2.orig/readline/readline/aclocal.m4 gdb-10.2/readline/readline/aclocal.m4
+index 1413267..7e7a303 100644
+--- gdb-10.2.orig/readline/readline/aclocal.m4
++++ gdb-10.2/readline/readline/aclocal.m4
+@@ -10,6 +10,7 @@ AC_DEFUN(BASH_C_LONG_LONG,
+   ac_cv_c_long_long=yes
+ else
+ AC_TRY_RUN([
++#include <stdlib.h>
+ int
+ main()
+ {
+@@ -33,6 +34,7 @@ AC_DEFUN(BASH_C_LONG_DOUBLE,
+   ac_cv_c_long_double=yes
+ else
+ AC_TRY_RUN([
++#include <stdlib.h>
+ int
+ main()
+ {
+@@ -134,6 +136,7 @@ typedef int (*_bashfunc)(const char *, ...);
+ #else
+ typedef int (*_bashfunc)();
+ #endif
++#include <stdlib.h>
+ main()
+ {
+ _bashfunc pf;
+@@ -191,6 +194,7 @@ AC_CACHE_VAL(bash_cv_under_sys_siglist,
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
++#include <stdlib.h>
+ #ifndef UNDER_SYS_SIGLIST_DECLARED
+ extern char *_sys_siglist[];
+ #endif
+@@ -218,6 +222,7 @@ AC_CACHE_VAL(bash_cv_sys_siglist,
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
++#include <stdlib.h>
+ #if !HAVE_DECL_SYS_SIGLIST
+ extern char *sys_siglist[];
+ #endif
+@@ -273,6 +278,7 @@ AC_CACHE_VAL(bash_cv_dup2_broken,
+ [AC_TRY_RUN([
+ #include <sys/types.h>
+ #include <fcntl.h>
++#include <stdlib.h>
+ main()
+ {
+   int fd1, fd2, fl;
+@@ -335,6 +341,7 @@ AC_CACHE_VAL(bash_cv_opendir_not_robust,
+ #  include <ndir.h>
+ # endif
+ #endif /* HAVE_DIRENT_H */
++#include <stdlib.h>
+ main()
+ {
+ DIR *dir;
+@@ -514,6 +521,7 @@ AC_TRY_RUN([
+ #include <sys/types.h>
+ #include <sys/time.h>
+ #include <sys/resource.h>
++#include <stdlib.h>
+ main()
+ {
+ #ifdef HAVE_QUAD_T
+@@ -583,6 +591,7 @@ AC_CACHE_VAL(bash_cv_getenv_redef,
+ #ifdef HAVE_UNISTD_H
+ #  include <unistd.h>
+ #endif
++#include <stdlib.h>
+ #ifndef __STDC__
+ #  ifndef const
+ #    define const
+@@ -786,6 +795,7 @@ AC_CACHE_VAL(bash_cv_func_sigsetjmp,
+ #include <sys/types.h>
+ #include <signal.h>
+ #include <setjmp.h>
++#include <stdlib.h>
+ 
+ main()
+ {
+@@ -835,8 +845,9 @@ AC_CACHE_VAL(bash_cv_func_strcoll_broken,
+ #if defined (HAVE_LOCALE_H)
+ #include <locale.h>
+ #endif
++#include <stringh>
+ 
+-main(c, v)
++int main(c, v)
+ int     c;
+ char    *v[];
+ {
+@@ -863,7 +874,7 @@ char    *v[];
+         /* Exit with 1 (failure) if these two values are both > 0, since
+ 	   this tests whether strcoll(3) is broken with respect to strcmp(3)
+ 	   in the default locale. */
+-	exit (r1 > 0 && r2 > 0);
++	return r1 > 0 && r2 > 0;
+ }
+ ], bash_cv_func_strcoll_broken=yes, bash_cv_func_strcoll_broken=no,
+    [AC_MSG_WARN(cannot check strcoll if cross compiling -- defaulting to no)
+@@ -881,6 +892,7 @@ AC_CACHE_VAL(bash_cv_printf_a_format,
+ [AC_TRY_RUN([
+ #include <stdio.h>
+ #include <string.h>
++#include <stdlib.h>
+ 
+ int
+ main()
+@@ -1241,6 +1253,7 @@ AC_CACHE_VAL(bash_cv_pgrp_pipe,
+ #ifdef HAVE_UNISTD_H
+ #  include <unistd.h>
+ #endif
++#include <stdlib.h>
+ main()
+ {
+ # ifdef GETPGRP_VOID
+@@ -1305,6 +1318,7 @@ AC_CACHE_VAL(bash_cv_must_reinstall_sighandlers,
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
++#include <stdlib.h>
+ 
+ typedef RETSIGTYPE sigfunc();
+ 
+@@ -1418,6 +1432,7 @@ AC_CACHE_VAL(bash_cv_sys_named_pipes,
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
++#include <stdlib.h>
+ 
+ /* Add more tests in here as appropriate. */
+ main()
+@@ -1651,6 +1666,7 @@ AC_CACHE_VAL(bash_cv_unusable_rtsigs,
+ [AC_TRY_RUN([
+ #include <sys/types.h>
+ #include <signal.h>
++#include <stdlib.h>
+ 
+ #ifndef NSIG
+ #  define NSIG 64
+@@ -1770,7 +1786,7 @@ bash_cv_wcwidth_broken,
+ #include <locale.h>
+ #include <wchar.h>
+ 
+-main(c, v)
++int main(c, v)
+ int     c;
+ char    **v;
+ {
+@@ -1834,6 +1850,7 @@ AC_CACHE_VAL(ac_cv_rl_version,
+ [AC_TRY_RUN([
+ #include <stdio.h>
+ #include <readline/readline.h>
++#include <stdlib.h>
+ 
+ extern int rl_gnu_readline_p;
+ 
+@@ -1927,7 +1944,7 @@ AC_CACHE_VAL(bash_cv_func_ctype_nonascii,
+ #include <stdio.h>
+ #include <ctype.h>
+ 
+-main(c, v)
++int main(c, v)
+ int	c;
+ char	*v[];
+ {
+@@ -1948,7 +1965,7 @@ char	*v[];
+ 	r1 = isprint(x);
+ 	x -= 128;
+ 	r2 = isprint(x);
+-	exit (r1 == 0 || r2 == 0);
++	return r1 == 0 || r2 == 0;
+ }
+ ], bash_cv_func_ctype_nonascii=yes, bash_cv_func_ctype_nonascii=no,
+    [AC_MSG_WARN(cannot check ctype macros if cross compiling -- defaulting to no)
+@@ -4068,6 +4085,7 @@ AC_DEFUN([BASH_FUNC_SNPRINTF],
+     AC_CACHE_CHECK([for standard-conformant snprintf], [bash_cv_func_snprintf],
+       [AC_TRY_RUN([
+ #include <stdio.h>
++#include <stdlib.h>
+ 
+ main()
+ {
+@@ -4154,7 +4172,7 @@ AC_CACHE_VAL(bash_cv_wexitstatus_offset,
+ 
+ #include <sys/wait.h>
+ 
+-main(c, v)
++int main(c, v)
+      int c;
+      char **v;
+ {
+diff --git gdb-10.2.orig/readline/readline/configure gdb-10.2/readline/readline/configure
+index de7499e..a53a885 100755
+--- gdb-10.2.orig/readline/readline/configure
++++ gdb-10.2/readline/readline/configure
+@@ -1,5 +1,5 @@
+ #! /bin/sh
+-# From configure.ac for Readline 8.0, version 2.85.
++# From configure.ac for Readline 8.0, version 2.86.
+ # Guess values for system-dependent variables and create Makefiles.
+ # Generated by GNU Autoconf 2.69 for readline 8.0.
+ #
+@@ -5316,6 +5316,7 @@ else
+ #ifdef HAVE_UNISTD_H
+ #include <unistd.h>
+ #endif
++#include <stdlib.h>
+ 
+ typedef RETSIGTYPE sigfunc();
+ 
+@@ -5346,7 +5347,7 @@ int s;
+   nsigint++;
+ }
+ 
+-main()
++int main(void)
+ {
+ 	nsigint = 0;
+ 	set_signal_handler(SIGINT, sigint);
+@@ -5396,8 +5397,9 @@ else
+ #include <sys/types.h>
+ #include <signal.h>
+ #include <setjmp.h>
++#include <stdlib.h>
+ 
+-main()
++int main(void)
+ {
+ #if !defined (_POSIX_VERSION) || !defined (HAVE_POSIX_SIGNALS)
+ exit (1);
+@@ -5499,8 +5501,9 @@ else
+ #if defined (HAVE_LOCALE_H)
+ #include <locale.h>
+ #endif
++#include <string.h>
+ 
+-main(c, v)
++int main(c, v)
+ int     c;
+ char    *v[];
+ {
+@@ -5527,7 +5530,7 @@ char    *v[];
+         /* Exit with 1 (failure) if these two values are both > 0, since
+ 	   this tests whether strcoll(3) is broken with respect to strcmp(3)
+ 	   in the default locale. */
+-	exit (r1 > 0 && r2 > 0);
++	return r1 > 0 && r2 > 0;
+ }
+ 
+ _ACEOF
+@@ -5570,7 +5573,7 @@ else
+ #include <stdio.h>
+ #include <ctype.h>
+ 
+-main(c, v)
++int main(c, v)
+ int	c;
+ char	*v[];
+ {
+@@ -5591,7 +5594,7 @@ char	*v[];
+ 	r1 = isprint(x);
+ 	x -= 128;
+ 	r2 = isprint(x);
+-	exit (r1 == 0 || r2 == 0);
++	return r1 == 0 || r2 == 0;
+ }
+ 
+ _ACEOF
+@@ -6713,7 +6716,7 @@ else
+ #include <locale.h>
+ #include <wchar.h>
+ 
+-main(c, v)
++int main(c, v)
+ int     c;
+ char    **v;
+ {
+diff --git gdb-10.2.orig/readline/readline/configure.ac gdb-10.2/readline/readline/configure.ac
+index b9b3e1c..399920c 100644
+--- gdb-10.2.orig/readline/readline/configure.ac
++++ gdb-10.2/readline/readline/configure.ac
+@@ -5,7 +5,7 @@ dnl report bugs to chet@po.cwru.edu
+ dnl
+ dnl Process this file with autoconf to produce a configure script.
+ 
+-# Copyright (C) 1987-2018 Free Software Foundation, Inc.
++# Copyright (C) 1987-2019 Free Software Foundation, Inc.
+ 
+ #   This program is free software: you can redistribute it and/or modify
+ #   it under the terms of the GNU General Public License as published by
+@@ -20,7 +20,7 @@ dnl Process this file with autoconf to produce a configure script.
+ #   You should have received a copy of the GNU General Public License
+ #   along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ 
+-AC_REVISION([for Readline 8.0, version 2.85])
++AC_REVISION([for Readline 8.0, version 2.86])
+ 
+ m4_include([../../config/override.m4])
+ 


### PR DESCRIPTION
These issues have been fixed in upstream GDB already:

In the file bfd/elf-bfd.h, startswith is now used in stead of strncmp.  libiberty was fixed via an import from GCC.  Readline 8.1 has been imported and has these issues fixed upstream.

Related to:

* https://fedoraproject.org/wiki/Changes/PortingToModernC
* https://fedoraproject.org/wiki/Toolchain/PortingToModernC
