### PR TITLE
crash/ppc64: Remove redundant PTE checks.

### DIFF
--- a/ppc64.c
+++ b/ppc64.c
@@ -968,9 +968,6 @@ ppc64_vtop(ulong vaddr, ulong *pgd, physaddr_t *paddr, int verbose)
 		return FALSE;
 	}
 
-	if (!pte)
-		return FALSE;
-
 	*paddr = PAGEBASE(PTOB(pte >> PTE_RPN_SHIFT_DEFAULT)) + PAGEOFFSET(vaddr);
 
 	if (verbose) {
@@ -1076,9 +1073,6 @@ ppc64_vtop_level4(ulong vaddr, ulong *level4, physaddr_t *paddr, int verbose)
 		}
 		return FALSE;
 	}
-
-	if (!pte)
-		return FALSE;
 
 out:
 	if (hugepage_type) {


### PR DESCRIPTION
Patch removes redundant checks for PTE (Page Table Entry) because those conditions are already covered.

        if (!(pte & _PAGE_PRESENT)) {
                ...
                return FALSE;
        }

        if (!pte)
                return FALSE;

The second pte check is redundant because it holds true only when pte is 0. if pte is 0 then (!(pte & _PAGE_PRESENT)) is true and it will return false. so there is no need for one more pte check.