### PR TITLE
deduplicate kernel_version open-coded parser

### DIFF
--- a/arm64.c
+++ b/arm64.c
@@ -834,35 +834,14 @@ static struct kernel_va_range_handler kernel_va_range_handlers[] = {
 static unsigned long arm64_get_kernel_version(void)
 {
 	char *string;
-	char buf[BUFSIZE];
-	char *p1, *p2;
 
 	if (THIS_KERNEL_VERSION)
 		return THIS_KERNEL_VERSION;
 
-	string = pc->read_vmcoreinfo("OSRELEASE");
-	if (string) {
-		strcpy(buf, string);
-
-		p1 = p2 = buf;
-		while (*p2 != '.')
-			p2++;
-		*p2 = NULLCHAR;
-		kt->kernel_version[0] = atoi(p1);
-
-		p1 = ++p2;
-		while (*p2 != '.')
-			p2++;
-		*p2 = NULLCHAR;
-		kt->kernel_version[1] = atoi(p1);
-
-		p1 = ++p2;
-		while ((*p2 >= '0') && (*p2 <= '9'))
-			p2++;
-		*p2 = NULLCHAR;
-		kt->kernel_version[2] = atoi(p1);
+	if ((string = pc->read_vmcoreinfo("OSRELEASE"))) {
+		parse_kernel_version(string);
+		free(string);
 	}
-	free(string);
 	return THIS_KERNEL_VERSION;
 }
 

--- a/defs.h
+++ b/defs.h
@@ -6032,6 +6032,8 @@ void clone_bt_info(struct bt_info *, struct bt_info *, struct task_context *);
 void dump_kernel_table(int);
 void dump_bt_info(struct bt_info *, char *where);
 void dump_log(int);
+void parse_kernel_version(char *);
+
 #define LOG_LEVEL(v) ((v) & 0x07)
 #define SHOW_LOG_LEVEL (0x1)
 #define SHOW_LOG_DICT  (0x2)

--- a/riscv64.c
+++ b/riscv64.c
@@ -259,33 +259,12 @@ riscv64_processor_speed(void)
 static unsigned long riscv64_get_kernel_version(void)
 {
 	char *string;
-	char buf[BUFSIZE];
-	char *p1, *p2;
 
 	if (THIS_KERNEL_VERSION)
 		return THIS_KERNEL_VERSION;
 
-	string = pc->read_vmcoreinfo("OSRELEASE");
-	if (string) {
-		strcpy(buf, string);
-
-		p1 = p2 = buf;
-		while (*p2 != '.')
-			p2++;
-		*p2 = NULLCHAR;
-		kt->kernel_version[0] = atoi(p1);
-
-		p1 = ++p2;
-		while (*p2 != '.')
-			p2++;
-		*p2 = NULLCHAR;
-		kt->kernel_version[1] = atoi(p1);
-
-		p1 = ++p2;
-		while ((*p2 >= '0') && (*p2 <= '9'))
-			p2++;
-		*p2 = NULLCHAR;
-		kt->kernel_version[2] = atoi(p1);
+	if ((string = pc->read_vmcoreinfo("OSRELEASE"))) {
+		parse_kernel_version(string);
 		free(string);
 	}
 	return THIS_KERNEL_VERSION;


### PR DESCRIPTION
The code that parses kernel version from OSRELEASE/UTSRELEASE strings
and populates the global kernel table is duplicated across the codebase
for no good reason. This commit consolidates all the duplicated parsing
code into a single method to remove the unnecessary duplicated code.