### PR TITLE
Swapped page read failure in Linux v6.1-rc4

### DIFF
--- a/defs.h
+++ b/defs.h
@@ -2227,6 +2227,7 @@ struct offset_table {                    /* stash of commonly-used offsets */
 	long module_memory_size;
 	long irq_data_irq;
 	long zspage_huge;
+	long zram_comp_algs;
 };
 
 struct size_table {         /* stash of commonly-used sizes */


### PR DESCRIPTION
When using the "rd" command to access a memory address swapped out to zram, it checks the compression method.
Previously, it accessed the "compressor" field in the zram struct to obtain the method.
However, starting from Linux v6.1-rc4 (due to commit 7ac07a26dea7, "zram: preparation for multi-zcomp support"), this field has been replaced by "comp_algs," leading to the following errors.
	rd: WARNING: Some pages are swapped out to zram. Please run mod -s zram.
	rd: invalid user virtual address: ffff7d23f010  type: "64-bit UVADDR"