### PR TITLE
Makefile: Pass CFLAGS when building extensions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -678,7 +678,7 @@ extensions: make_configure
 	@$(MAKE) do_extensions
 
 do_extensions:
-	@$(MAKE) -C extensions -i TARGET=$(TARGET) TARGET_CFLAGS="$(TARGET_CFLAGS)" GDB=$(GDB) GDB_FLAGS=$(GDB_FLAGS)
+	@$(MAKE) -C extensions -i TARGET=$(TARGET) TARGET_CFLAGS="$(CFLAGS) $(TARGET_CFLAGS)" GDB=$(GDB) GDB_FLAGS=$(GDB_FLAGS)
 
 memory_driver: make_configure 
 	@$(MAKE) -C memory_driver -i


### PR DESCRIPTION
When building the extensions in distributions, ensure they are built
with the CFLAGS from distributions build system.
