### PR TITLE
Prevent double-free strbuf when nsyms is 0

### DIFF
--- a/symbols.c
+++ b/symbols.c
@@ -2076,6 +2076,8 @@ store_module_symbols_6_4(ulong total, int mods_installed)
 				strbuf = NULL;
 			}
 		}
+		else
+			strbuf = NULL;
 
 
 		for (i = 0; i < nsyms; i++) {


### PR DESCRIPTION
When nsyms is 0, 'last' will be equal to 'first', and strbuf will not get a new memory buf. But strbuf is not NULL now, because in the last loop, strbuf may get a memory buf allocated by 'calloc', which is only freed in the loop end but not set to NULL. If we don't set strbuf to NULL in such a case, strbuf will be double freed in the following FREEBUF(strbuf) sentence.