### PR TITLE
extensions/Makefile: eliminate race condition

### DIFF
--- a/extensions/Makefile
+++ b/extensions/Makefile
@@ -36,16 +36,13 @@ $(CONTRIB_SO): %.so: %.c defs.h
 	@if [ -f $*.mk ]; then \
 		$(MAKE) -f $*.mk; \
 	else \
-		grep '((constructor))' $*.c > .constructor; \
-		if [ -s .constructor ]; then \
+		grep -q '((constructor))' $*.c && { \
 			echo "gcc -Wall -g -shared -rdynamic -o $@ $*.c -fPIC -D$(TARGET) $(TARGET_CFLAGS) $(GDB_FLAGS)"; \
 			gcc -Wall -g -shared -rdynamic -o $@ $*.c -fPIC -D$(TARGET) $(TARGET_CFLAGS) $(GDB_FLAGS); \
-		fi; \
-		if [ ! -s .constructor ]; then \
+		} || { \
 			echo "gcc -Wall -g -nostartfiles -shared -rdynamic -o $@ $*.c -fPIC -D$(TARGET) $(TARGET_CFLAGS) $(GDB_FLAGS)"; \
 			gcc -Wall -g -nostartfiles -shared -rdynamic -o $@ $*.c -fPIC -D$(TARGET) $(TARGET_CFLAGS) $(GDB_FLAGS); \
-		fi; \
-		rm -f .constructor; \
+		}; \
 	fi
 
 clean:


### PR DESCRIPTION
Building extensions with parallel jobs could lead to a race condition when creating and using the temporary `.constructor` file. This resulted in unpredictable build outcomes and unreproducible builds. This commit removes the temporary file entirely, resolving the race condition and ensuring consistent builds.

Before:
```
$ make clean
$ make -j1 extensions
$ sha256sum extensions/dminfo.so 
e99dfea1baaae188072ece419fa65e3027004ef244f4fec3e15262988cadeb86  extensions/dminfo.so

$ make clean
$ make -j4 extensions
$ sha256sum extensions/dminfo.so 
565fe5c3d050b4254543169230ee4e6f770afb9a89eb9bbfe5f9fbca3399fe09  extensions/dminfo.so
```

After:
```
$ make clean
$ make -j1 extensions
$ sha256sum extensions/dminfo.so 
e99dfea1baaae188072ece419fa65e3027004ef244f4fec3e15262988cadeb86  extensions/dminfo.so

$ make clean
$ make -j4 extensions
$ sha256sum extensions/dminfo.so 
e99dfea1baaae188072ece419fa65e3027004ef244f4fec3e15262988cadeb86  extensions/dminfo.so
```