### PR TITLE
bpf: minor improvement when listing used_maps

### DIFF
--- a/bpf.c
+++ b/bpf.c
@@ -880,6 +880,7 @@ bpf_prog_used_maps(int idx, char *retbuf)
 				sprintf(&retbuf[strlen(retbuf)], "%s%ld", 
 					strlen(retbuf) ? "," : "",
 					bpf->maplist[m].index);
+				break;
 			}
 		}
 	}


### PR DESCRIPTION
Just stop iteration when an used_map is found.