### PR TITLE
module_init(): handle newer kernels that removed gpl_syms and num_gpl…

### DIFF
--- a/kernel.c
+++ b/kernel.c
@@ -3634,8 +3634,10 @@ module_init(void)
 	case KMOD_V2: 
 		MEMBER_OFFSET_INIT(module_num_syms, "module", "num_syms");
 		MEMBER_OFFSET_INIT(module_list, "module", "list");
-        	MEMBER_OFFSET_INIT(module_gpl_syms, "module", "gpl_syms");
-        	MEMBER_OFFSET_INIT(module_num_gpl_syms, "module", 
+		if (MEMBER_EXISTS("module", "gpl_syms"))
+			MEMBER_OFFSET_INIT(module_gpl_syms, "module", "gpl_syms");
+		if (MEMBER_EXISTS("module", "num_gpl_syms"))
+			MEMBER_OFFSET_INIT(module_num_gpl_syms, "module",
 			"num_gpl_syms");
 
 		if (MEMBER_EXISTS("module", "mem")) {	/* 6.4 and later */
@@ -3830,8 +3832,9 @@ module_init(void)
                 	nsyms = UINT(modbuf + OFFSET(module_nsyms));
 			break;
 		case KMOD_V2: 
-                	nsyms = UINT(modbuf + OFFSET(module_num_syms)) +
-				UINT(modbuf + OFFSET(module_num_gpl_syms));
+			nsyms = UINT(modbuf + OFFSET(module_num_syms));
+			if (VALID_MEMBER(module_num_gpl_syms))
+				nsyms += UINT(modbuf + OFFSET(module_num_gpl_syms));
 			break;
 		}
 

--- a/symbols.c
+++ b/symbols.c
@@ -1976,9 +1976,11 @@ store_module_symbols_6_4(ulong total, int mods_installed)
 			"module buffer", FAULT_ON_ERROR);
 
 		syms = ULONG(modbuf + OFFSET(module_syms));
-		gpl_syms = ULONG(modbuf + OFFSET(module_gpl_syms));
+		gpl_syms = VALID_MEMBER(module_gpl_syms) ?
+			ULONG(modbuf + OFFSET(module_gpl_syms)) : 0;
 		nsyms = UINT(modbuf + OFFSET(module_num_syms));
-		ngplsyms = UINT(modbuf + OFFSET(module_num_gpl_syms));
+		ngplsyms = VALID_MEMBER(module_num_gpl_syms) ?
+			UINT(modbuf + OFFSET(module_num_gpl_syms)) : 0;
 
 		nksyms = UINT(modbuf + OFFSET(module_num_symtab));
 
@@ -2336,9 +2338,11 @@ store_module_symbols_v2(ulong total, int mods_installed)
 			"module buffer", FAULT_ON_ERROR);
 
 		syms = ULONG(modbuf + OFFSET(module_syms));
-		gpl_syms = ULONG(modbuf + OFFSET(module_gpl_syms));
+		gpl_syms = VALID_MEMBER(module_gpl_syms) ?
+			ULONG(modbuf + OFFSET(module_gpl_syms)) : 0;
                 nsyms = UINT(modbuf + OFFSET(module_num_syms));
-                ngplsyms = UINT(modbuf + OFFSET(module_num_gpl_syms));
+                ngplsyms = VALID_MEMBER(module_num_gpl_syms) ?
+			UINT(modbuf + OFFSET(module_num_gpl_syms)) : 0;
 
 		if (THIS_KERNEL_VERSION >= LINUX(2,6,27)) {
 			nksyms = UINT(modbuf + OFFSET(module_num_symtab));


### PR DESCRIPTION
…_syms

In Linux kernel commit 55fcb92 ("module: use kflagstab instead of *_gpl sections") and b4760ff ("module: deprecate usage of *_gpl sections in module loader"), the kernel merged GPL-only symbol sections into the regular symbol table, tracked by a new per-symbol flags table (kflagstab).  This removed the following fields from struct module:

  - num_gpl_syms
  - gpl_syms
  - gpl_crcs

Without this patch, crash fails to start a session with a newer kernel vmcore with this error:

  crash: invalid structure member offset: module_num_gpl_syms
         FILE: kernel.c  LINE: 3834  FUNCTION: module_init()

The fix makes the gpl_syms/num_gpl_syms member initialization and usage conditional in both module_init() and store_module_symbols() paths.  When these members do not exist, gpl_syms is set to 0 and ngplsyms is set to 0, so the GPL symbol loading loops are simply skipped.

This is consistent with how the kernel itself now handles symbols: all exported symbols (including GPL-only) are stored in a single syms array with per-symbol flags in flagstab.